### PR TITLE
Add link to first PR

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,3 +13,6 @@ To start, please follow these steps:
 Remember to pull the latest changes before starting your work and push your updates when you're done.
 
 Happy Learning!
+
+First PR:
+https://pkg.go.dev/github.com/gin-gonic/gin


### PR DESCRIPTION
This pull request adds a link to the first PR in the project documentation. The link points to the documentation for the gin-gonic/gin package on pkg.go.dev.